### PR TITLE
perf: replace len(string(rune)) with utf8.RuneLen avoiding temporary string allocations

### DIFF
--- a/basic.go
+++ b/basic.go
@@ -100,7 +100,7 @@ func Any(str string) Combinator[string] {
 		for _, sc := range s {
 			for _, strc := range str {
 				if sc == strc {
-					pos = pos + len(string(strc))
+					pos = pos + utf8.RuneLen(strc)
 					continue match
 				}
 			}
@@ -133,7 +133,7 @@ func Not(str string) Combinator[string] {
 				}
 			}
 
-			pos = pos + len(string(sc))
+			pos = pos + utf8.RuneLen(sc)
 		}
 
 		if pos == 0 {
@@ -257,9 +257,9 @@ func Escaped(normal Combinator[string], escape rune, escapable Combinator[string
 				continue
 			}
 
-			runes := []rune(rem)
-			if len(runes) > 0 && runes[0] == escape {
-				escLen := len(string(escape))
+			r, _ := utf8.DecodeRuneInString(rem)
+			if r == escape {
+				escLen := utf8.RuneLen(escape)
 				if len(rem) <= escLen {
 					break
 				}
@@ -311,9 +311,9 @@ func EscapedTransform(normal Combinator[string], escape rune, transform Combinat
 				continue
 			}
 
-			runes := []rune(rem)
-			if len(runes) > 0 && runes[0] == escape {
-				escLen := len(string(escape))
+			r, _ := utf8.DecodeRuneInString(rem)
+			if r == escape {
+				escLen := utf8.RuneLen(escape)
 				if len(rem) <= escLen {
 					break
 				}

--- a/predicate.go
+++ b/predicate.go
@@ -3,6 +3,7 @@ package chomp
 import (
 	"fmt"
 	"unicode"
+	"unicode/utf8"
 )
 
 // Predicate defines an expression that will return either true or false
@@ -181,7 +182,7 @@ func WhileN(p Predicate, n uint) Combinator[string] {
 			if !p.Match(c) {
 				break
 			}
-			pos += len(string(c))
+			pos += utf8.RuneLen(c)
 		}
 
 		if uint(pos) < n {
@@ -209,7 +210,7 @@ func WhileNM(p Predicate, n, m uint) Combinator[string] {
 			if !p.Match(c) {
 				break
 			}
-			pos += len(string(c))
+			pos += utf8.RuneLen(c)
 		}
 
 		if uint(pos) < n || uint(pos) > m {
@@ -250,7 +251,7 @@ func WhileNotN(p Predicate, n uint) Combinator[string] {
 			if p.Match(c) {
 				break
 			}
-			pos += len(string(c))
+			pos += utf8.RuneLen(c)
 		}
 
 		if uint(pos) < n {
@@ -279,7 +280,7 @@ func WhileNotNM(p Predicate, n, m uint) Combinator[string] {
 			if p.Match(c) {
 				break
 			}
-			pos += len(string(c))
+			pos += utf8.RuneLen(c)
 		}
 
 		if uint(pos) < n || uint(pos) > m {


### PR DESCRIPTION
closes #97